### PR TITLE
Change default os_type from RancherOS to ContainerLinux

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -82,7 +82,7 @@ Environment variables and default values:
 | `--sakuracloud-access-token`         | `SAKURACLOUD_ACCESS_TOKEN`        | -                        |
 | `--sakuracloud-access-token-secret`  | `SAKURACLOUD_ACCESS_TOKEN_SECRET` | -                        |
 | `--sakuracloud-zone`                 | `SAKURACLOUD_ZONE`                | `is1b`                   |
-| `--sakuracloud-os-type`              | `SAKURACLOUD_OS_TYPE`             | `rancheros`              |
+| `--sakuracloud-os-type`              | `SAKURACLOUD_OS_TYPE`             | `coreos`                 |
 | `--sakuracloud-core`                 | `SAKURACLOUD_CORE`                | `1`                      |
 | `--sakuracloud-memory`               | `SAKURACLOUD_MEMORY`              | `1`                      |
 | `--sakuracloud-disk-connection`      | `SAKURACLOUD_DISK_CONNECTION`     | `virtio`                 |

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ SandboxリージョンについてはSSHにてログインができないため�
 | `--sakuracloud-access-token`         | `SAKURACLOUD_ACCESS_TOKEN`        | -                        |
 | `--sakuracloud-access-token-secret`  | `SAKURACLOUD_ACCESS_TOKEN_SECRET` | -                        |
 | `--sakuracloud-zone`                 | `SAKURACLOUD_ZONE`                | `is1b`                   |
-| `--sakuracloud-os-type`              | `SAKURACLOUD_OS_TYPE`             | `rancheros`              |
+| `--sakuracloud-os-type`              | `SAKURACLOUD_OS_TYPE`             | `coreos`                 |
 | `--sakuracloud-core`                 | `SAKURACLOUD_CORE`                | `1`                      |
 | `--sakuracloud-memory`               | `SAKURACLOUD_MEMORY`              | `1`                      |
 | `--sakuracloud-disk-connection`      | `SAKURACLOUD_DISK_CONNECTION`     | `virtio`                 |

--- a/driver/spec.go
+++ b/driver/spec.go
@@ -8,14 +8,14 @@ import (
 )
 
 var (
-	defaultRegion          = "is1b"      // 石狩第2ゾーン
-	defaultOSType          = "rancheros" // OSタイプ
-	defaultCore            = 1           // デフォルトコア数
-	defaultMemorySize      = 1           // デフォルトメモリサイズ
-	defaultDiskPlan        = "ssd"       // ディスクプラン(ssd/hdd)
-	defaultDiskSize        = 20          // 20GB
-	defaultDiskConnection  = "virtio"    // ディスク接続ドライバ
-	defaultInterfaceDriver = "virtio"    // NIC接続ドライバ
+	defaultRegion          = "is1b"   // 石狩第2ゾーン
+	defaultOSType          = "coreos" // OSタイプ
+	defaultCore            = 1        // デフォルトコア数
+	defaultMemorySize      = 1        // デフォルトメモリサイズ
+	defaultDiskPlan        = "ssd"    // ディスクプラン(ssd/hdd)
+	defaultDiskSize        = 20       // 20GB
+	defaultDiskConnection  = "virtio" // ディスク接続ドライバ
+	defaultInterfaceDriver = "virtio" // NIC接続ドライバ
 	defaultPacketFilter    = ""
 	defaultEnablePWAuth    = false
 )


### PR DESCRIPTION
さくらのクラウドで提供されているRancherOSのバージョンは v1.4となっており、v1.4ではメモリ要件が1280MB以上となっている。
> refs: https://qiita.com/yamamoto-febc/items/1e27fec8031b2dd0c072

docker-machibe-sakuracloudで作成するサーバのメモリサイズのデフォルト値は1GBなため、
RancherOSを利用する場合は`--sakuracloud-memory`オプションで2以上を指定する必要がある。

このため、デフォルトのメモリ1GBで利用できるOSの中でもっとも高速にプロビジョニング可能なContainerLinux(`os_type` = `coreos`)をデフォルト値とする。


