### PR TITLE
APIClientへのパスワードフィールドの追加

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -88,6 +88,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		flags.String("sakuracloud-access-token"),
 		flags.String("sakuracloud-access-token-secret"),
 		flags.String("sakuracloud-zone"),
+		flags.String("sakuracloud-password"),
 	)
 	if err := d.getClient().ValidateClientConfig(); err != nil {
 		return err
@@ -265,8 +266,9 @@ func (d *Driver) prepareSSHKey() (string, error) {
 
 func (d *Driver) preparePassword() {
 	if d.serverConfig.Password == "" {
-		d.serverConfig.Password = generateRandomPassword()
-		log.Infof("password is not set, generated.[password:%s]", d.serverConfig.Password)
+		d.Client.Password = generateRandomPassword()
+		log.Infof("password is not set, generated.[password:%s]", d.Client.Password)
+		d.serverConfig.Password = d.Client.Password
 	}
 }
 

--- a/sakuracloud/client.go
+++ b/sakuracloud/client.go
@@ -18,6 +18,7 @@ type APIClient struct {
 	AccessTokenSecret string
 	Zone              string
 	Region            string // 後方互換
+	Password          string // config storeへ残しておくため
 
 	/*
 		Note: 以下エクスポートしていない項目は適切にconfig storeからのUnmarshalに対応すること
@@ -29,13 +30,14 @@ type APIClient struct {
 }
 
 // NewAPIClient returns new APIClient
-func NewAPIClient(token string, secret string, zone string) *APIClient {
+func NewAPIClient(token, secret, zone, password string) *APIClient {
 	caller := initCaller(token, secret)
 
 	return &APIClient{
 		AccessToken:       token,
 		AccessTokenSecret: secret,
 		Zone:              zone,
+		Password:          password,
 		caller:            caller,
 	}
 }


### PR DESCRIPTION
パスワードは`Driver.serverConfig`に保持しているがエクスポートしていないためConfig Storeに保存されない。これを修正し`Driver.APIClient`のエクスポートされたフィールドとしてパスワードを追加する。