### PR TITLE
Added --sakuracloud-gpu parameter

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -58,9 +58,9 @@ func validateSakuraServerConfig(c *sakuracloud.APIClient, config *sakuraServerCo
 		return fmt.Errorf("invalid parameter: %s", err)
 	}
 
-	res, err := c.IsValidPlan(config.Core, config.Memory)
+	res, err := c.IsValidPlan(config.Core, config.Memory, config.GPU)
 	if !res || err != nil {
-		return fmt.Errorf("invalid parameter: core or memory is invalid : %v", err)
+		return fmt.Errorf("invalid parameter: invalid plan: core/memory/gpu : %v", err)
 	}
 
 	if config.PacketFilter != "" {
@@ -103,6 +103,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		OSType:          flags.String("sakuracloud-os-type"),
 		Core:            flags.Int("sakuracloud-core"),
 		Memory:          flags.Int("sakuracloud-memory"),
+		GPU:            flags.Int("sakuracloud-gpu"),
 		DiskPlan:        flags.String("sakuracloud-disk-plan"),
 		DiskSize:        flags.Int("sakuracloud-disk-size"),
 		DiskConnection:  flags.String("sakuracloud-disk-connection"),
@@ -395,6 +396,7 @@ func (d *Driver) buildSakuraServerSpec(publicKey string) *server.Builder {
 		Name:            d.serverConfig.HostName,
 		CPU:             d.serverConfig.Core,
 		MemoryGB:        d.serverConfig.Memory,
+		GPU: d.serverConfig.GPU,
 		Commitment:      types.Commitments.Standard, // TODO パラメータ化
 		Generation:      types.PlanGenerations.Default,
 		InterfaceDriver: interfaceDriver,

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -103,7 +103,7 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		OSType:          flags.String("sakuracloud-os-type"),
 		Core:            flags.Int("sakuracloud-core"),
 		Memory:          flags.Int("sakuracloud-memory"),
-		GPU:            flags.Int("sakuracloud-gpu"),
+		GPU:             flags.Int("sakuracloud-gpu"),
 		DiskPlan:        flags.String("sakuracloud-disk-plan"),
 		DiskSize:        flags.Int("sakuracloud-disk-size"),
 		DiskConnection:  flags.String("sakuracloud-disk-connection"),
@@ -396,7 +396,7 @@ func (d *Driver) buildSakuraServerSpec(publicKey string) *server.Builder {
 		Name:            d.serverConfig.HostName,
 		CPU:             d.serverConfig.Core,
 		MemoryGB:        d.serverConfig.Memory,
-		GPU: d.serverConfig.GPU,
+		GPU:             d.serverConfig.GPU,
 		Commitment:      types.Commitments.Standard, // TODO パラメータ化
 		Generation:      types.PlanGenerations.Default,
 		InterfaceDriver: interfaceDriver,

--- a/driver/spec.go
+++ b/driver/spec.go
@@ -35,7 +35,7 @@ type sakuraServerConfig struct {
 	OSType          string
 	Core            int
 	Memory          int
-	GPU int
+	GPU             int
 	DiskPlan        string
 	DiskSize        int
 	DiskConnection  string

--- a/driver/spec.go
+++ b/driver/spec.go
@@ -35,6 +35,7 @@ type sakuraServerConfig struct {
 	OSType          string
 	Core            int
 	Memory          int
+	GPU int
 	DiskPlan        string
 	DiskSize        int
 	DiskConnection  string
@@ -168,6 +169,11 @@ var mcnFlags = []mcnflag.Flag{
 		Name:   "sakuracloud-memory",
 		Usage:  "sakuracloud memory size(GB)",
 		Value:  defaultMemorySize,
+	},
+	mcnflag.IntFlag{
+		EnvVar: "SAKURACLOUD_GPU",
+		Name:   "sakuracloud-gpu",
+		Usage:  "sakuracloud number of GPUs",
 	},
 	mcnflag.StringFlag{
 		EnvVar: "SAKURACLOUD_DISK_PLAN",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/docker/docker v20.10.5+incompatible // indirect
 	github.com/docker/machine v0.16.2
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
-	github.com/sacloud/libsacloud/v2 v2.16.0
+	github.com/sacloud/libsacloud/v2 v2.26.1-0.20211008014615-db5d9d9b3689
 	github.com/stretchr/testify v1.6.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
-github.com/sacloud/libsacloud/v2 v2.16.0 h1:qEGmVhE/WOMBayha1U4H4tVdjpWxLvc/uCRGbYQUrmA=
-github.com/sacloud/libsacloud/v2 v2.16.0/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
+github.com/sacloud/libsacloud/v2 v2.26.1-0.20211008014615-db5d9d9b3689 h1:VuJSxzMSmWWUgcR3FKoitWS51KQpJLk7ur29BrOV5SE=
+github.com/sacloud/libsacloud/v2 v2.26.1-0.20211008014615-db5d9d9b3689/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/sakuracloud/client.go
+++ b/sakuracloud/client.go
@@ -95,11 +95,11 @@ func (c *APIClient) ValidateClientConfig() error {
 }
 
 // IsValidPlan validates plan
-func (c *APIClient) IsValidPlan(core ,memory, gpu int) (bool, error) {
+func (c *APIClient) IsValidPlan(core, memory, gpu int) (bool, error) {
 	plan, err := query.FindServerPlan(context.Background(), sacloud.NewServerPlanOp(c.caller), c.Zone, &query.FindServerPlanRequest{
 		CPU:      core,
 		MemoryGB: memory,
-		GPU: gpu,
+		GPU:      gpu,
 	})
 	if err != nil {
 		return false, err

--- a/sakuracloud/client.go
+++ b/sakuracloud/client.go
@@ -95,10 +95,11 @@ func (c *APIClient) ValidateClientConfig() error {
 }
 
 // IsValidPlan validates plan
-func (c *APIClient) IsValidPlan(core int, memory int) (bool, error) {
+func (c *APIClient) IsValidPlan(core ,memory, gpu int) (bool, error) {
 	plan, err := query.FindServerPlan(context.Background(), sacloud.NewServerPlanOp(c.caller), c.Zone, &query.FindServerPlanRequest{
 		CPU:      core,
 		MemoryGB: memory,
+		GPU: gpu,
 	})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
GPUプランを指定可能にする。

利用例:

```bash
# docker/machineでも同様
$ rancher-machine create -d sakuracloud --sakuracloud-core 4 --sakuracloud-memory 56 --sakuracloud-gpu 1 --sakuracloud-zone is1a --sakuracloud-os-type ubuntu example
```